### PR TITLE
feat: add imagetag property

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   imagename:
     description: 'container image name'
     required: true
+  imagetag:
+    description: 'container image tag'
+    required: false
   dockerfile:
     description: 'Dockerfile name - optional - default is Dockerfile'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,6 +44,9 @@ if [ "$VERSION" == "master" ] || [ "$VERSION" == "main" ]; then
     VERSION=latest
 fi
 
+if [ -n "$INPUT_IMAGETAG" ]; then
+    VERSION="$INPUT_IMAGETAG"
+
 IMAGE_ID="$INPUT_GITREPO_LOWERCASE/$INPUT_IMAGENAME"
 
 # login to registry


### PR DESCRIPTION
You can override the tag by setting the `imagetag` property. E.g.

`imagetag: 1.0.0-251002160619`

This functionality was needed for the new pax.ch website since the docker image consumes the Storyblok API and the response can differ, depending on the date that the build is run.